### PR TITLE
Add O2 and LTCG flag for MSVC Windows branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if(UNIX)
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-variable -Wno-sign-compare -Wno-unused-function -Wno-strict-aliasing")
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -O3")
 endif(UNIX)
+
+if(MSVC)
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -LTCG")
+endif(MSVC)
+
 # SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -fPIC -g -O3")
 # SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -fPIC -O3 -g")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ if(UNIX)
 endif(UNIX)
 
 if(MSVC)
-   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -LTCG")
+   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
+   if(CMAKE_BUILD_TYPE STREQUAL "Release")
+      set_target_properties(GameplayFootball PROPERTIES LINK_FLAGS "$<$<CONFIG:Release>:/LTCG>")
+   endif()
 endif(MSVC)
 
 # SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -fPIC -g -O3")


### PR DESCRIPTION
CMakeList current just optimize for Unix. Clang and GNU GCC have O3 flag for optimize performance code. MSVC doesn't have O3, so I use O2 flag for speed and LTCG for force compiler use inline function every time.
In my personal test, I saw in task manager, use O2 and LTCG help to improve estimate 2% ~ 5% CPU usage.

[LTCG flag](https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160)
[O2 flag](https://docs.microsoft.com/en-us/cpp/build/reference/o1-o2-minimize-size-maximize-speed?view=msvc-160)

