### PR TITLE
Enhance build configuration and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 cmake-build*/
+out/
 .idea/
 .vs/
+vcpkg_installed/
 Release/
 Debug/
 data/log.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.20)
 
 set(PACKAGE GameplayFootball)
 
@@ -14,6 +14,9 @@ endif(${VERSION_PATCH})
 #set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules")
 
 project(GameplayFootball)
+
+option(GAMEPLAYFOOTBALL_WINDOWS_SUBSYSTEM
+   "Build without a console window on Windows" OFF)
 
 set (CMAKE_CXX_STANDARD 14)
 
@@ -35,28 +38,25 @@ endif(MSVC)
 # SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -fPIC -O3 -g")
 
 # Find required libraries
-FIND_PACKAGE(OpenGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIR})
+find_package(OpenGL REQUIRED)
 
-FIND_PACKAGE(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR})
+find_package(SDL2 CONFIG REQUIRED)
 
-FIND_PACKAGE(SDL2-image REQUIRED)
-include_directories(${SDL2_IMAGE_DIRS})
+find_package(SDL2_image CONFIG REQUIRED)
 
-FIND_PACKAGE(SDL2-ttf REQUIRED)
-include_directories(${SDL2_TTF_DIRS})
+find_package(SDL2_ttf CONFIG REQUIRED)
 
-FIND_PACKAGE(SDL2-gfx REQUIRED)
-include_directories(${SDL2_GFX_DIRS})
+find_package(Boost CONFIG REQUIRED COMPONENTS system thread filesystem)
 
-FIND_PACKAGE(Boost REQUIRED COMPONENTS system thread filesystem)
-include_directories(${Boost_INCLUDE_DIR})
-
-FIND_PACKAGE(OpenAL REQUIRED)
-include_directories(${OPENAL_INCLUDE_DIR})
+find_package(OpenAL CONFIG REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
+
+add_library(gameplayfootball_dependencies INTERFACE)
+target_link_libraries(gameplayfootball_dependencies INTERFACE
+   Boost::system Boost::thread Boost::filesystem
+   SDL2::SDL2 SDL2::SDL2main SDL2_image::SDL2_image SDL2_ttf::SDL2_ttf
+   OpenAL::OpenAL OpenGL::GL)
 
 # Include the sources
 include(sources.cmake)
@@ -103,10 +103,27 @@ add_library(hidlib ${HID_SOURCES} ${HID_HEADERS})
 add_library(menulib ${MENU_SOURCES} ${MENU_HEADERS})
 add_library(datalib ${DATA_SOURCES} ${DATA_HEADERS})
 
-set(LIBRARIES gamelib hidlib menulib datalib leaguelib blunted2
-   ${Boost_LIBRARIES} SDL2::SDL2 SDL2::SDL2main SDL2::SDL2_image SDL2::SDL2_ttf SDL2::SDL2_gfx
-   ${OPENAL_LIBRARY} ${OPENGL_LIBRARY})
+set(INTERNAL_TARGETS baselib systemscommonlib systemsgraphicslib systemsaudiolib
+   loaderslib typeslib frameworklib scenelib managerslib utilslib gui2lib
+   blunted2 leaguelib gamelib hidlib menulib datalib)
+foreach(target IN LISTS INTERNAL_TARGETS)
+   target_link_libraries(${target} PUBLIC gameplayfootball_dependencies)
+endforeach()
+
+set(LIBRARIES gamelib hidlib menulib datalib leaguelib blunted2)
 
 
-add_executable(gameplayfootball WIN32 ${CORE_SOURCES} ${CORE_HEADERS})
-target_link_libraries(gameplayfootball ${LIBRARIES})
+if(WIN32 AND GAMEPLAYFOOTBALL_WINDOWS_SUBSYSTEM)
+   add_executable(gameplayfootball WIN32 ${CORE_SOURCES} ${CORE_HEADERS})
+else()
+   add_executable(gameplayfootball ${CORE_SOURCES} ${CORE_HEADERS})
+endif()
+target_link_libraries(gameplayfootball PRIVATE ${LIBRARIES})
+target_link_libraries(gameplayfootball PRIVATE gameplayfootball_dependencies)
+
+# Keep runtime assets beside the executable so launching it from Explorer uses
+# the same layout as launching it from the build directory.
+add_custom_command(TARGET gameplayfootball POST_BUILD
+   COMMAND ${CMAKE_COMMAND} -E copy_directory
+      "${PROJECT_SOURCE_DIR}/data"
+      "$<TARGET_FILE_DIR:gameplayfootball>")

--- a/README.md
+++ b/README.md
@@ -1,182 +1,126 @@
 # Gameplay Football
+
 Football game, a fork of discontinued [GameplayFootball](https://github.com/BazkieBumpercar/GameplayFootball) written by [Bastiaan Konings Schuiling](http://www.properlydecent.com/).
 
-In 2019, Google Brain team picked up a game and created a Reinforcement Learning environment based on it - [Google Research Football](https://github.com/google-research/football). They made some improvements to the game, updated the libraries, but threw away everything (e.g. menus, audio effects, etc.) that was not necessary for their task.
+In 2019, Google Brain team picked up the game and created a Reinforcement Learning environment based on it - [Google Research Football](https://github.com/google-research/football). They made some improvements to the game, updated the libraries, but removed everything that was not necessary for their task, including menus and audio effects.
 
-The goal of this repository is to update the existing code, based on Google Brain's changes (see `google_brain` branch) and other forks, and make it compiling and running on as many platforms as possible. PRs are always welcome.  
+The goal of this repository is to update the existing code, based on Google Brain's changes and other forks, and make it compile and run on as many platforms as possible. PRs are welcome.
 
-# Building from source
+## Building from source
 
-## Linux
-Install required dependencies: 
-```bash
+The project uses CMake. On Windows, dependencies are managed by vcpkg manifest mode through vcpkg.json. You do not need to run a separate classic-mode vcpkg install command.
+
+### Linux
+
+Install the required dependencies:
+
+~~~bash
 sudo apt-get install git cmake build-essential libgl1-mesa-dev libsdl2-dev \
-libsdl2-image-dev libsdl2-ttf-dev libsdl2-gfx-dev libopenal-dev libboost-all-dev \
+libsdl2-image-dev libsdl2-ttf-dev libopenal-dev libboost-all-dev \
 libdirectfb-dev libst-dev mesa-utils xvfb x11vnc python3-pip
-```
+~~~
 
-Run the following commands:
-```bash
-# Clone the repository
+Configure and build:
+
+~~~bash
 git clone https://github.com/vi3itor/GameplayFootball.git
 cd GameplayFootball
+cmake -S . -B build
+cmake --build build --parallel
+~~~
 
-# Copy the contents of `data` directory into `build`
-cp -R data/. build
+Run from the build directory so the relative asset paths resolve:
 
-# Go to `build` directory
+~~~bash
 cd build
-# Generate Makefile
-cmake ..
-# Compile the game
-make -j$(nproc)
-```
-
-Run the game:
-```bash
 ./gameplayfootball
-```
+~~~
 
-## MacOS (Work in Progress)
-**Important**: Currently, the game can be compiled on Mac OS, but it is not running yet, because rendering must be done on the Main Thread.
+### macOS (work in progress)
 
-To install required dependencies you need [`brew`](https://brew.sh/) which can be installed in Terminal by running:
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-```
+The project can compile on macOS, but rendering still requires additional work because the renderer currently expects to run on the main thread.
 
-```bash
-# Install dependencies
-brew install git cmake sdl2 sdl2_image sdl2_ttf sdl2_gfx boost openal-soft
-# Navigate to the directory where you want to put the repository
-cd ~
-# Clone the repository
+Install dependencies with [Homebrew](https://brew.sh/):
+
+~~~bash
+brew install git cmake sdl2 sdl2_image sdl2_ttf boost openal-soft
+~~~
+
+Configure and build:
+
+~~~bash
 git clone https://github.com/vi3itor/GameplayFootball.git
 cd GameplayFootball
-# Copy the contents of `data` directory into `build`
-cp -R data/. build
+cmake -S . -B build
+cmake --build build --parallel
+~~~
 
-# Go to `build` directory
-cd build
-# Generate Makefile
-cmake ..
-# Compile the game
-make -j$(nproc)
+### Windows
 
-# Run the game (Currently is not working)
-./gameplayfootball
-```
+Install:
 
-## Windows (Work in Progress) 
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/) with **Desktop development with C++** and CMake tools for Windows.
+- [CMake](https://cmake.org/download/) 3.20 or newer, if it is not included in your Visual Studio installation.
+- [Git](https://git-scm.com/download/win).
 
-Download and install:
-- [Git](https://git-scm.com/download/win),
-- [CMake](https://cmake.org/download/) (make sure to add it to the system PATH).
-Install [`vcpkg`](https://github.com/microsoft/vcpkg) as explained in [Quick Start Guide](https://github.com/microsoft/vcpkg#quick-start-windows) or simply:
-create a directory, e.g. `C:\dev`, open Command Prompt and run the following commands: 
-```bat
-% Navigate to the created directory
-cd C:\dev
+Visual Studio includes a vcpkg installation. A separate classic-mode vcpkg installation and vcpkg integrate install are not required. If you use another vcpkg installation, set VCPKG_ROOT to its root directory.
 
-% Clone vckpg
-git clone https://github.com/microsoft/vcpkg
+Clone the repository:
 
-% Run installation script
-.\vcpkg\bootstrap-vcpkg.bat
+~~~powershell
+git clone https://github.com/vi3itor/GameplayFootball.git
+Set-Location GameplayFootball
+~~~
 
-% Run integrate Vcpkg with Visual Studio
-.\vcpkg\vcpkg integrate install
+Configure a 64-bit Visual Studio 2026 build. The manifest automatically restores the dependencies:
 
-% Install required dependencies (all triplets **must be `x86-windows`**):
-.\vcpkg\vcpkg install --triplet x86-windows boost:x86-windows sdl2 sdl2-image[libjpeg-turbo] sdl2-ttf sdl2-gfx opengl openal-soft
-```
+~~~powershell
+$env:VCPKG_ROOT = 'C:\Program Files\Microsoft Visual Studio\18\Community\VC\vcpkg'
+$toolchain = Join-Path $env:VCPKG_ROOT 'scripts\buildsystems\vcpkg.cmake'
+cmake -S . -B out\build\x64-debug -G 'Visual Studio 18 2026' -A x64 "-DCMAKE_TOOLCHAIN_FILE=$toolchain" -DVCPKG_TARGET_TRIPLET=x64-windows
+~~~
 
-Clone project
-```bat
-% Navigate to the directory where you want to put the repository
-cd C:\dev
+Build Debug:
 
-% Clone repository
-git clone https://github.com/vi3itor/GameplayFootball.git 
-cd GameplayFootball
+~~~powershell
+cmake --build out\build\x64-debug --config Debug --parallel 4
+~~~
 
-% Switch to windows branch
-git switch windows
-```
+Build Release or RelWithDebInfo:
 
-Now we have 2 options:
+~~~powershell
+cmake --build out\build\x64-debug --config Release --parallel 4
+cmake --build out\build\x64-debug --config RelWithDebInfo --parallel 4
+~~~
 
-### 1. Visual Studio 2019 - Support Debugging and Profiling game
+The build automatically copies the contents of data beside the executable. The output locations are:
 
-Download and install:
-- [Visual Studio 2019 with Desktop development with C++](https://visualstudio.microsoft.com/downloads/),
- 
-![Desktop C++](https://docs.microsoft.com/en-us/cpp/build/media/vscpp-concierge-choose-workload.gif?view=msvc-150)
-- [C++ CMake tools for Windows](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-160).
+~~~text
+out\build\x64-debug\Debug\gameplayfootball.exe
+out\build\x64-debug\Release\gameplayfootball.exe
+out\build\x64-debug\RelWithDebInfo\gameplayfootball.exe
+~~~
 
-![CMake tool](https://docs.microsoft.com/en-us/cpp/build/media/cmake-install-2019.png?view=msvc-160)
+Run the game from its executable directory. This is also what launching the .exe from Windows Explorer does:
 
-Build project
-- Start `Visual Studio 2019`, then click `File > Open > Folder...`
-- Navigate to the `GameplayFootball` project folder, and click `Select Folder`
-- Select `x86-Debug` or `x86-ReleaseDebugSymbol` and `x86-Release` mode in drop down menu `Manage Configurations...`
+~~~powershell
+Push-Location out\build\x64-debug\Debug
+.\gameplayfootball.exe
+Pop-Location
+~~~
 
-![Manage Configurations...](https://docs.microsoft.com/en-us/visualstudio/ide/media/understanding-build-configurations/active-config.png?view=vs-2019)
-- Click `gameplayfootball.exe` in menu `Select startup item...` to start build game
+To run without a console window, configure with:
 
-![Select startup item...](https://docs.microsoft.com/en-us/cpp/build/media/cmake-run-button.png?view=msvc-160)
-- After build success, game will start but it close immediately, because it missing data. Now go to step copy data to game
+~~~powershell
+cmake -S . -B out\build\x64-release -G 'Visual Studio 18 2026' -A x64 "-DCMAKE_TOOLCHAIN_FILE=$toolchain" -DVCPKG_TARGET_TRIPLET=x64-windows -DGAMEPLAYFOOTBALL_WINDOWS_SUBSYSTEM=ON
+~~~
 
-To copy data to game, switch back to Command Prompt window
-```bat
-% Copy the contents of `data` directory into `out\build\x86-Debug` or `out\build\x86-Release` or `out\build\x86-ReleaseDebugSymbol`
-xcopy /e /i data out\build\x86-Debug
-xcopy /e /i data out\build\x86-Release
-xcopy /e /i data out\build\x86-ReleaseDebugSymbol
-```
-Now switch back Visual Studio, press F5, now project can start successful. You can [add breakpoint](https://docs.microsoft.com/en-us/visualstudio/debugger/using-breakpoints?view=vs-2019) or [start profiling tools](https://docs.microsoft.com/en-us/visualstudio/profiling/profiling-feature-tour?view=vs-2019)
+For debugging, leave GAMEPLAYFOOTBALL_WINDOWS_SUBSYSTEM disabled so startup errors remain visible in the terminal. Runtime diagnostics are written to log.txt beside the executable.
 
-NOTE:
-- Release mode can NOT add breakpoint.
-- Visual Studio 2019 support Release mode with Debug symbol, which mean the build is Release but you can add breakpoint. In project, this is `x86-ReleaseDebugSymbol`
+## Problems?
 
-### 2. Visual Studio Code - Support Building
-- [Visual Studio Code](https://code.visualstudio.com/),
-- [C/C++ for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
-![C++ VS Code](https://code.visualstudio.com/assets/docs/cpp/cpp/cpp-extension.png)
-
-- [C/C++ Extension Pack for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools-extension-pack).
-
-- [Build tools 2019 with Desktop development with C++](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019)
-
-To copy data to game, switch to Command Prompt window
-```bat
-% Copy the contents of `data` directory into `build\Debug` or (and) `build\Release` or (and) `build\RelWithDebInfo`
-xcopy /e /i data build\Debug
-xcopy /e /i data build\Release
-xcopy /e /i data build\RelWithDebInfo
-```
-
-Build project
-- Add Vcpkg folder as `VCPKG_ROOT` to system environment. e.g. `C:\dev\vcpkg`
-- Start `Visual Studio Code`, then click `File > Open Folder...`
-- Navigate to the `GameplayFootball` project folder, and click `Select Folder`
-- Open `c_cpp_properties.json` file, add `compilerPath` your compiler path when you installed Build tool. For example `C:/Program Files (x86)/Microsoft Visual Studio/2019/Buildtools/VC/Tools/MSVC/14.xx.xxxxx/bin/Hostx64/x86/cl.exe` with `x` is your `Build tools` version.
-- Look at `status bar` below VS code window, we can see several button:
-    - Current build variant
-    - The active kit
-    - Build selected target
-    - Launch the debugger
-    - Launch the selected target
-- Click active kit button (select compiler installed on computer) choose Visual Studio 2019 build tools amd64-x86.
-- Click build button.
-- After build click play icon to start game
-
-NOTE:
-- Launch the debugger still have bug. If you need debugger, please switch to Visual Studio 2019.
-
-## Problems? 
-If you have any problems please open an issue. 
+If you have problems, please open an issue with the CMake configure output, build configuration, and log.txt.
 
 ### Donate
-If you want to thank Bastiaan for his great work, consider a donation to his Bitcoin address 1JHnTe2QQj8RL281fXFiyvK9igj2VhPh2t
+
+If you want to thank Bastiaan for his great work, consider a donation to his Bitcoin address 1JHnTe2QQj8RL281fXFiyvK9igj2VhPh2t.

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -48,13 +48,7 @@ namespace blunted {
 
     if (logType == e_FatalError) {
       LogClose();
-
-#ifndef NDEBUG
-      // for gdb backtracing
-      int *foo = (int*)-1; // make a bad pointer
-      printf("%d\n", *foo); // causes segfault
-#endif
-
+      fflush(stdout);
       exit(1);
     }
   }

--- a/src/base/sdl_surface.cpp
+++ b/src/base/sdl_surface.cpp
@@ -11,6 +11,21 @@ namespace blunted {
     return SDL_CreateRGBSurface(SDL_SWSURFACE | SDL_RLEACCEL, width, height, 32, r_mask, g_mask, b_mask, a_mask);
   }
 
+  SDL_Surface *sdl_resize_surface(const SDL_Surface *surface, int width, int height) {
+    if (!surface || width <= 0 || height <= 0) return 0;
+
+    SDL_Surface *resized = SDL_CreateRGBSurfaceWithFormat(
+        0, width, height, surface->format->BitsPerPixel, surface->format->format);
+    if (!resized) return 0;
+
+    SDL_Rect destination = { 0, 0, width, height };
+    if (SDL_BlitScaled(const_cast<SDL_Surface *>(surface), 0, resized, &destination) != 0) {
+      SDL_FreeSurface(resized);
+      return 0;
+    }
+    return resized;
+  }
+
   void sdl_putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel) {
 
     int bpp = surface->format->BytesPerPixel;

--- a/src/base/sdl_surface.hpp
+++ b/src/base/sdl_surface.hpp
@@ -8,8 +8,6 @@
 #include "SDL2/SDL_image.h"
 #include "SDL2/SDL_endian.h"
 
-#include "SDL2/SDL2_gfxPrimitives.h"
-
 namespace blunted {
 
   class Triangle;
@@ -39,6 +37,7 @@ namespace blunted {
   #endif
 
   SDL_Surface *CreateSDLSurface(int width, int height);
+  SDL_Surface *sdl_resize_surface(const SDL_Surface *surface, int width, int height);
   void sdl_putpixel(SDL_Surface *surface, int x, int y, Uint32 pixel);
   Uint32 sdl_getpixel(const SDL_Surface *surface, int x, int y);
   void sdl_line(SDL_Surface *surface, int x1, int y1, int x2, int y2, Uint32 color);

--- a/src/menu/ingame/radar.cpp
+++ b/src/menu/ingame/radar.cpp
@@ -7,8 +7,6 @@
 #include "utils/gui2/windowmanager.hpp"
 
 #include <SDL2/SDL.h>
-#include <SDL2/SDL2_rotozoom.h>
-
 #include "../../gamedefines.hpp"
 
 #include "../../onthepitch/match.hpp"

--- a/src/menu/ingame/tacticsdebug.cpp
+++ b/src/menu/ingame/tacticsdebug.cpp
@@ -7,8 +7,6 @@
 #include "utils/gui2/windowmanager.hpp"
 
 #include <SDL2/SDL.h>
-#include <SDL2/SDL2_rotozoom.h>
-
 #include "../../gamedefines.hpp"
 
 #include "../../onthepitch/match.hpp"

--- a/src/scene/resources/surface.cpp
+++ b/src/scene/resources/surface.cpp
@@ -6,8 +6,6 @@
 
 #include "base/log.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
-
 namespace blunted {
 
   Surface::Surface() : surface(0) {
@@ -38,11 +36,6 @@ namespace blunted {
 
   void Surface::Resize(int x, int y) {
 
-    // zoomSurface doesn't seem to create a completely new surface; got some weird segfaults.
-    // not 100% sure if it's their fault though, or if i'm doing something wrong. either way,
-    // it works with this fix, though it's a bit of a performance hit, an extra surface copy.
-    bool buggyZoomSurface = true;
-
     assert(this->surface);
     int xcur = this->surface->w;
     int ycur = this->surface->h;
@@ -52,17 +45,13 @@ namespace blunted {
     if (yfac == 0) yfac = xfac;
     if (xfac == 0) xfac = yfac;
     if (xfac == 0 || yfac == 0) return;
-    SDL_Surface *newSurf = zoomSurface(this->surface, xfac, yfac, SMOOTHING_ON);
+    SDL_Surface *newSurf = sdl_resize_surface(this->surface, int(round(xcur * xfac)), int(round(ycur * yfac)));
     //printf("resize factors: %f %f\n", xfac, yfac);
     //printf("surface size: %i %i\n", this->surface->w, this->surface->h);
     //printf("new surface size: %i %i\n", newSurf->w, newSurf->h);
+    if (!newSurf) return;
     SDL_FreeSurface(this->surface);
-    if (buggyZoomSurface) {
-      this->surface = SDL_ConvertSurface(newSurf, newSurf->format, 0);
-      SDL_FreeSurface(newSurf);
-    } else {
-      this->surface = newSurf;
-    }
+    this->surface = newSurf;
   }
 
   void Surface::GetSize(int &x, int &y) {

--- a/src/systems/graphics/rendering/opengl_renderer3d.cpp
+++ b/src/systems/graphics/rendering/opengl_renderer3d.cpp
@@ -352,7 +352,10 @@ struct GLfunctions {
 
 //#ifdef WIN32
     // SDL subsystems must be initialized before setting attributes
-    SDL_Init(SDL_INIT_VIDEO);
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+      Log(e_Error, "OpenGLRenderer3D", "CreateContext", "SDL video initialization failed: " + std::string(SDL_GetError()));
+      return false;
+    }
 
     SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
@@ -364,9 +367,11 @@ struct GLfunctions {
 
     SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 
-    //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-    //SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    // The renderer uses both shader/VBO functions and the compatibility
+    // profile's immediate-mode calls (glBegin/glEnd).
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 
     // todo: remember to enable this later on, after migrating to sdl 2 (though it is on by default with most drivers, or so it seems)
     //SDL_GL_SetAttribute(SDL_GL_FRAMEBUFFER_SRGB_CAPABLE, 1);
@@ -384,7 +389,28 @@ struct GLfunctions {
                                 SDL_WINDOWPOS_UNDEFINED, width, height,
                                 SDL_WINDOW_OPENGL /* | SDL_RESIZABLE*/ |
                                 (fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
+    if (!window) {
+      Log(e_Error, "OpenGLRenderer3D", "CreateContext", "SDL window creation failed: " + std::string(SDL_GetError()));
+      return false;
+    }
     context = SDL_GL_CreateContext(window);
+    if (!context) {
+      Log(e_Error, "OpenGLRenderer3D", "CreateContext", "OpenGL context creation failed: " + std::string(SDL_GetError()));
+      SDL_DestroyWindow(window);
+      window = 0;
+      return false;
+    }
+
+    // Capture the actual adapter/context before loading extension functions.
+    // This is especially useful on Windows systems with hybrid or DisplayLink
+    // graphics, where the active OpenGL provider may be limited to 1.1.
+    const GLubyte *contextVersion = ::glGetString(GL_VERSION);
+    const GLubyte *glVendor = ::glGetString(GL_VENDOR);
+    const GLubyte *glRenderer = ::glGetString(GL_RENDERER);
+    printf("OpenGL context: version=%s vendor=%s renderer=%s\n",
+           contextVersion ? reinterpret_cast<const char *>(contextVersion) : "unknown",
+           glVendor ? reinterpret_cast<const char *>(glVendor) : "unknown",
+           glRenderer ? reinterpret_cast<const char *>(glRenderer) : "unknown");
 
 
     //    *reinterpret_cast<void**>(&(mapping.func)) =
@@ -396,9 +422,14 @@ struct GLfunctions {
         SDL_GL_GetProcAddress(#func);                                      \
     if (!mapping.func) {                                                   \
       printf("Couldn't load GL function %s: %s\n", #func, SDL_GetError()); \
-      SDL_SetError("Couldn't load GL function %s: %s\n", #func,            \
-                   SDL_GetError());                                        \
-      exit(1);                                                             \
+      const std::string error = "Couldn't load GL function " #func ": " +  \
+          std::string(SDL_GetError());                                     \
+      Log(e_Error, "OpenGLRenderer3D", "CreateContext", error);           \
+      SDL_GL_DeleteContext(context);                                        \
+      context = 0;                                                          \
+      SDL_DestroyWindow(window);                                             \
+      window = 0;                                                           \
+      return false;                                                         \
     }                                                                      \
   } while (0);
 #include "sdl_glfuncs.h"
@@ -412,11 +443,6 @@ struct GLfunctions {
     mapping.glGetIntegerv(GL_MINOR_VERSION, &glVersion[1]);
 
     Log(e_Notice, "OpenGLRenderer3D", "CreateContext", "OpenGL major/minor " + int_to_str(glVersion[0]) + "." + int_to_str(glVersion[1]));
-    if (!context) {
-      std::string errorString = SDL_GetError();
-      Log(e_FatalError, "OpenGLRenderer3D", "CreateContext", "Failed on SDL error: " + errorString);
-      return false;
-    }
     bool higherThan32 = false;
     if (glVersion[0] < 4) {
       if (glVersion[0] == 3 && glVersion[1] >= 2) higherThan32 = true;

--- a/src/utils/gui2/widgets/button.cpp
+++ b/src/utils/gui2/widgets/button.cpp
@@ -4,8 +4,6 @@
 
 #include "button.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
-
 namespace blunted {
 
   Gui2Button::Gui2Button(Gui2WindowManager *windowManager, const std::string &name, float x_percent, float y_percent, float width_percent, float height_percent, const std::string &caption) : Gui2View(windowManager, name, x_percent, y_percent, width_percent, height_percent) {

--- a/src/utils/gui2/widgets/caption.cpp
+++ b/src/utils/gui2/widgets/caption.cpp
@@ -6,7 +6,7 @@
 
 #include "../windowmanager.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
+#include "base/sdl_surface.hpp"
 
 namespace blunted {
 
@@ -74,8 +74,10 @@ namespace blunted {
     float zoomy;
     renderedTextHeightPix = (float)textOutlineSurfTmp->h;
     zoomy = (float)(h - y_margin * 2) / renderedTextHeightPix;
-    SDL_Surface *textOutlineSurf = zoomSurface(textOutlineSurfTmp, zoomy, zoomy, 1);
-    SDL_Surface *textSurf = zoomSurface(textSurfTmp, zoomy, zoomy, 1);
+    SDL_Surface *textOutlineSurf = sdl_resize_surface(
+        textOutlineSurfTmp, int(round(textOutlineSurfTmp->w * zoomy)), int(round(textOutlineSurfTmp->h * zoomy)));
+    SDL_Surface *textSurf = sdl_resize_surface(
+        textSurfTmp, int(round(textSurfTmp->w * zoomy)), int(round(textSurfTmp->h * zoomy)));
     SDL_FreeSurface(textOutlineSurfTmp);
     SDL_FreeSurface(textSurfTmp);
 

--- a/src/utils/gui2/widgets/iconselector.cpp
+++ b/src/utils/gui2/widgets/iconselector.cpp
@@ -6,8 +6,6 @@
 
 #include "../windowmanager.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
-
 namespace blunted {
 
   Gui2IconSelector::Gui2IconSelector(Gui2WindowManager *windowManager, const std::string &name, float x_percent, float y_percent, float width_percent, float height_percent, const std::string &caption) : Gui2View(windowManager, name, x_percent, y_percent, width_percent, height_percent), caption(caption) {

--- a/src/utils/gui2/widgets/image.cpp
+++ b/src/utils/gui2/widgets/image.cpp
@@ -19,7 +19,7 @@
 
 #include "../windowmanager.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
+#include "base/sdl_surface.hpp"
 
 namespace blunted {
 
@@ -62,11 +62,7 @@ Gui2Image::Gui2Image(Gui2WindowManager *windowManager, const std::string &name,
       int x, y, w, h;
       windowManager->GetCoordinates(x_percent, y_percent, width_percent, height_percent, x, y, w, h);
 
-      double zoomx;
-      zoomx = (double)w / imageSurfTmp->w;
-      double zoomy;
-      zoomy = (double)h / imageSurfTmp->h;
-      SDL_Surface *imageSurf = zoomSurface(imageSurfTmp, zoomx, zoomy, 1);
+      SDL_Surface *imageSurf = sdl_resize_surface(imageSurfTmp, int(round(w)), int(round(h)));
       //printf("actually resized to %i %i\n", imageSurf->w, imageSurf->h);
 
       surfaceRes->resourceMutex.unlock();
@@ -113,11 +109,7 @@ Gui2Image::Gui2Image(Gui2WindowManager *windowManager, const std::string &name,
       int x, y, w, h;
       windowManager->GetCoordinates(x_percent, y_percent, width_percent, height_percent, x, y, w, h);
 
-      double zoomx1;
-      zoomx1 = (double)w / imageSurfTmp->w * zoomx;
-      double zoomy1;
-      zoomy1 = (double)h / imageSurfTmp->h * zoomy;
-      SDL_Surface *imageSurf = zoomSurface(imageSurfTmp, zoomx1, zoomy1, 1);
+      SDL_Surface *imageSurf = sdl_resize_surface(imageSurfTmp, int(round(w * zoomx)), int(round(h * zoomy)));
       //printf("actually resized to %i %i\n", imageSurf->w, imageSurf->h);
 
       surfaceRes->resourceMutex.unlock();

--- a/src/utils/gui2/widgets/slider.cpp
+++ b/src/utils/gui2/widgets/slider.cpp
@@ -6,8 +6,6 @@
 
 #include "../windowmanager.hpp"
 
-#include "SDL2/SDL2_rotozoom.h"
-
 namespace blunted {
 
   Gui2Slider::Gui2Slider(Gui2WindowManager *windowManager, const std::string &name, float x_percent, float y_percent, float width_percent, float height_percent, const std::string &caption) : Gui2View(windowManager, name, x_percent, y_percent, width_percent, height_percent), quantizationSteps(51), caption(caption) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "gameplayfootball",
+  "version-string": "0.3.0",
+  "builtin-baseline": "ea1a7396b05637a53bf23c078647ecc0edee4b80",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-system",
+    "boost-thread",
+    "boost-signals2",
+    "boost-random",
+    "boost-circular-buffer",
+    "sdl2",
+    {
+      "name": "sdl2-image",
+      "features": ["libjpeg-turbo"]
+    },
+    "sdl2-ttf",
+    "openal-soft"
+  ]
+}


### PR DESCRIPTION
- Updated CMake minimum version to 3.20 and added Windows subsystem option.
- Improved SDL surface handling with a new resizing function.
- Cleaned up unused SDL2_rotozoom includes across multiple files.
- Added vcpkg.json for dependency management with vcpkg.
- Updated .gitignore to include new build directories.
- Enhanced error logging for SDL initialization and context creation.